### PR TITLE
Add unit tests with simple Catch2 harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ Se mostrará un menú interactivo donde podrá:
 - Generar un resumen estadístico de las coincidencias encontradas.
 - Exportar los resultados detallados a un archivo HTML.
 
+## Pruebas
+
+El directorio `tests` contiene una versión simplificada del framework
+Catch2 y varios casos de prueba. Para compilarlos y ejecutarlos use:
+
+```bash
+g++ -std=c++17 PatternMatcher.cpp ui.cpp tests/test_cases.cpp \
+    tests/test_main.cpp -o tests/tests
+./tests/tests
+```
+
+Se mostrará un resumen indicando cuántas pruebas pasaron o fallaron.
+

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -1,0 +1,33 @@
+#ifndef CATCH_HPP
+#define CATCH_HPP
+
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace Catch {
+struct TestCase { std::string name; std::function<void()> func; };
+inline std::vector<TestCase>& registry() { static std::vector<TestCase> tests; return tests; }
+struct Registrar { Registrar(const std::string& n, std::function<void()> f){ registry().push_back({n,f}); } };
+inline int run() {
+    int failures = 0;
+    for(const auto& tc : registry()) {
+        try { tc.func(); std::cout << "[PASSED] " << tc.name << "\n"; }
+        catch(const std::exception& e){ ++failures; std::cout << "[FAILED] "<<tc.name<<" - "<<e.what()<<"\n"; }
+        catch(...){ ++failures; std::cout << "[FAILED] "<<tc.name<<" - unknown error\n"; }
+    }
+    std::cout << (registry().size()-failures) << "/" << registry().size() << " tests passed\n";
+    return failures;
+}
+} // namespace Catch
+
+#define TEST_CASE(name) \
+    static void name(); \
+    static Catch::Registrar registrar_##name(#name, name); \
+    static void name()
+
+#define REQUIRE(cond) do { if(!(cond)) throw std::runtime_error("Requirement failed: " #cond); } while(0)
+
+#endif // CATCH_HPP

--- a/tests/test_cases.cpp
+++ b/tests/test_cases.cpp
@@ -1,0 +1,33 @@
+#include "catch.hpp"
+#include "../PatternMatcher.h"
+#include "../ui.h"
+#include <fstream>
+#include <cstdio>
+
+TEST_CASE(trie_construction) {
+    ahocorasick::PatternMatcher matcher;
+    matcher.initialize({"he", "she", "hers"});
+    REQUIRE(matcher.patterns().size() == 3);
+    REQUIRE(matcher.node_count() > 3);
+    REQUIRE(matcher.max_depth() >= 3);
+}
+
+TEST_CASE(pattern_search) {
+    ahocorasick::PatternMatcher matcher;
+    matcher.initialize({"he", "she", "hers"});
+    auto results = matcher.search("ushers");
+    REQUIRE(results.size() == 3);
+    REQUIRE(results[0].pattern == "she");
+}
+
+TEST_CASE(file_loading) {
+    const char* fname = "tmp_patterns.txt";
+    {
+        std::ofstream out(fname);
+        out << "alpha\nbeta\n";
+    }
+    auto patterns = ui::load_patterns_from_file(fname);
+    std::remove(fname);
+    REQUIRE(patterns.size() == 2);
+    REQUIRE(patterns[0] == "alpha");
+}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,4 @@
+#include "catch.hpp"
+int main(){
+    return Catch::run();
+}


### PR DESCRIPTION
## Summary
- add a minimal Catch2-style header
- provide test cases for trie building, search and file loading
- document how to compile and run tests in README

## Testing
- `g++ -std=c++17 PatternMatcher.cpp ui.cpp tests/test_cases.cpp tests/test_main.cpp -o tests/tests && ./tests/tests`

------
https://chatgpt.com/codex/tasks/task_e_687a92bd6c54832785114ebf11ae903a